### PR TITLE
Make `bad_variant_access` inherit publicly from `std::exception`.

### DIFF
--- a/include/swl/variant.hpp
+++ b/include/swl/variant.hpp
@@ -66,7 +66,7 @@ SOFTWARE.
 
 namespace swl {
 
-class bad_variant_access  final : std::exception {
+class bad_variant_access  final : public std::exception {
 	const char* message = ""; // llvm test requires a well formed what() on default init
 	public : 
 	bad_variant_access(const char* str) noexcept : message{str} {}


### PR DESCRIPTION
I'm guessing the (default) private inheritance is just a typo? It causes a C4673 warning in MSVC in our project:

```
D:\a\cesium-unreal\cesium-unreal\packages\CesiumForUnreal\HostProject\Plugins\CesiumForUnreal\Source\ThirdParty\include\swl\variant.hpp(656): error C4673: throwing 'swl::bad_variant_access' the following types will not be considered at the catch site
D:\a\cesium-unreal\cesium-unreal\packages\CesiumForUnreal\HostProject\Plugins\CesiumForUnreal\Source\CesiumEditor\Private\CesiumIonTokenTroubleshooting.cpp(148): note: see reference to function template instantiation 'Rtype swl::visit<`anonymous-namespace'::isNull::<lambda_1>,const CesiumIonObject&>(Fn &&,const CesiumIonObject &)' being compiled
        with
        [
            Rtype=bool,
            Fn=`anonymous-namespace'::isNull::<lambda_1>
        ]
D:\a\cesium-unreal\cesium-unreal\packages\CesiumForUnreal\HostProject\Plugins\CesiumForUnreal\Source\ThirdParty\include\swl\variant.hpp(656): error C4670: 'exception': this base class is inaccessible
```

We're currently using swl-variant at the head of main.
